### PR TITLE
[enhancement] Refactor GetTodos component into hook and sub-components

### DIFF
--- a/src/components/GetTodos.tsx
+++ b/src/components/GetTodos.tsx
@@ -1,64 +1,14 @@
-import {
-  Action,
-  ActionPanel,
-  Color,
-  Detail,
-  getPreferenceValues,
-  Icon,
-  List,
-  openExtensionPreferences,
-  showToast,
-  Toast,
-} from "@raycast/api";
-import { useEffect, useState } from "react";
-import {
-  capitalizeFirstLetter,
-  formatVisualDate,
-  getPriorityColor,
-  getWorkspaceColor,
-  getWorkspaceIcon,
-  isOverdue,
-  missingPreferences,
-  getTomorrow,
-  getNextMonday,
-} from "../utils";
-import { Todo, TodoFilter, Workspaces, TodoDateGroup, Preferences } from "../types";
-import { fetchTodosFromWorkspace, markTodoCompleted, updateTodo, deleteTodo, createTodo } from "../notion";
-import { EditTodoForm } from "./EditTodoForm";
-
-const FILTERS: TodoFilter[] = [TodoFilter.ALL, TodoFilter.PERSONAL, TodoFilter.WORK];
-
-function getNextFilter(current: TodoFilter): TodoFilter {
-  const idx = FILTERS.indexOf(current);
-  return FILTERS[(idx + 1) % FILTERS.length];
-}
-
-function getPrevFilter(current: TodoFilter): TodoFilter {
-  const idx = FILTERS.indexOf(current);
-  return FILTERS[(idx - 1 + FILTERS.length) % FILTERS.length];
-}
+import { Action, ActionPanel, Detail, getPreferenceValues, List, openExtensionPreferences } from "@raycast/api";
+import { missingPreferences } from "../utils";
+import { Preferences } from "../types";
+import { useTodos } from "../hooks/useTodos";
+import { TodoListItem } from "./TodoListItem";
+import { TodoFilterDropdown } from "./TodoFilterDropdown";
 
 export default function GetTodosCommand() {
   const prefs = getPreferenceValues<Preferences>();
   const missing = missingPreferences(prefs);
-  const [todos, setTodos] = useState<Todo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<TodoFilter>(TodoFilter.ALL);
-
-  useEffect(() => {
-    async function loadTodos() {
-      setLoading(true);
-      const [personalTodos, workTodos] = await Promise.all([
-        fetchTodosFromWorkspace(Workspaces.PERSONAL),
-        fetchTodosFromWorkspace(Workspaces.WORK),
-      ]);
-      setTodos([...personalTodos, ...workTodos]);
-      setLoading(false);
-    }
-    if (missing.length === 0) {
-      loadTodos();
-    }
-  }, []);
+  const { setTodos, loading, filter, setFilter, grouped } = useTodos();
 
   if (missing.length > 0) {
     return (
@@ -73,249 +23,23 @@ export default function GetTodosCommand() {
     );
   }
 
-  // First, filter by workspace and completion status, then sort by dueDate
-  const filteredTodos = todos
-    .filter((todo) => {
-      if (filter === TodoFilter.PERSONAL) return todo.workspace === Workspaces.PERSONAL && !todo.done;
-      if (filter === TodoFilter.WORK) return todo.workspace === Workspaces.WORK && !todo.done;
-      return !todo.done;
-    })
-    .sort((a, b) => {
-      if (!a.dueDate) return 1;
-      if (!b.dueDate) return -1;
-      return a.dueDate.localeCompare(b.dueDate);
-    });
-
-  // Group todos by date category
-  function getDateCategory(dateStr?: string): TodoDateGroup {
-    if (!dateStr) return TodoDateGroup.NO_DATE;
-    const today = new Date();
-    const date = new Date(dateStr);
-    today.setHours(0, 0, 0, 0);
-    date.setHours(0, 0, 0, 0);
-    const diffDays = Math.round((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-    if (diffDays < 0) return TodoDateGroup.PAST;
-    if (diffDays === 0) return TodoDateGroup.TODAY;
-    if (diffDays === 1) return TodoDateGroup.TOMORROW;
-    if (diffDays > 1 && diffDays <= 7) return TodoDateGroup.NEXT_WEEK;
-    if (diffDays > 7) return TodoDateGroup.LATER;
-    return TodoDateGroup.NO_DATE;
-  }
-
-  const grouped: Record<TodoDateGroup, typeof filteredTodos> = {
-    [TodoDateGroup.PAST]: [],
-    [TodoDateGroup.TODAY]: [],
-    [TodoDateGroup.TOMORROW]: [],
-    [TodoDateGroup.NEXT_WEEK]: [],
-    [TodoDateGroup.LATER]: [],
-    [TodoDateGroup.NO_DATE]: [],
-  };
-  filteredTodos.forEach((todo) => {
-    const cat = getDateCategory(todo.dueDate);
-    grouped[cat].push(todo);
-  });
-
   return (
     <List
       isLoading={loading}
       searchBarPlaceholder="Search todos..."
-      searchBarAccessory={
-        <List.Dropdown tooltip="Filter Todos" value={filter} onChange={(value) => setFilter(value as TodoFilter)}>
-          <List.Dropdown.Item title={capitalizeFirstLetter(TodoFilter.ALL)} value={TodoFilter.ALL} />
-          <List.Dropdown.Item
-            title={capitalizeFirstLetter(TodoFilter.PERSONAL)}
-            value={TodoFilter.PERSONAL}
-            icon={Icon.Person}
-          />
-          <List.Dropdown.Item
-            title={capitalizeFirstLetter(TodoFilter.WORK)}
-            value={TodoFilter.WORK}
-            icon={Icon.Building}
-          />
-        </List.Dropdown>
-      }
+      searchBarAccessory={<TodoFilterDropdown filter={filter} onFilterChange={setFilter} />}
     >
-      {Object.entries(grouped).map(([section, todos]) =>
-        todos.length > 0 ? (
+      {Object.entries(grouped).map(([section, sectionTodos]) =>
+        sectionTodos.length > 0 ? (
           <List.Section key={section} title={section}>
-            {todos.map((todo) => (
-              <List.Item
+            {sectionTodos.map((todo) => (
+              <TodoListItem
                 key={todo.id}
-                title={todo.title}
-                subtitle={todo.notes}
-                icon={todo.done ? { source: Icon.CheckCircle, tintColor: Color.Green } : Icon.Circle}
-                accessories={[
-                  ...[
-                    {
-                      icon: { source: getWorkspaceIcon(todo.workspace), tintColor: getWorkspaceColor(todo.workspace) },
-                      tooltip:
-                        todo.workspace === Workspaces.PERSONAL
-                          ? capitalizeFirstLetter(Workspaces.PERSONAL)
-                          : capitalizeFirstLetter(Workspaces.WORK),
-                    },
-                    ...(todo.priority
-                      ? [
-                          {
-                            tag: { value: todo.priority, color: getPriorityColor(todo.priority) },
-                          },
-                        ]
-                      : []),
-                    ...(todo.dueDate
-                      ? [
-                          {
-                            text: isOverdue(todo.dueDate)
-                              ? `🔴 ${formatVisualDate(new Date(todo.dueDate))}`
-                              : formatVisualDate(new Date(todo.dueDate)),
-                            icon: Icon.Calendar,
-                            tooltip: new Date(todo.dueDate).toLocaleDateString(),
-                          },
-                        ]
-                      : []),
-                  ],
-                ]}
-                actions={
-                  <ActionPanel>
-                    {!todo.done && (
-                      <Action
-                        title="Mark as Completed"
-                        onAction={async () => {
-                          const success = await markTodoCompleted(todo.id, todo.workspace);
-                          if (success) {
-                            setTodos((prev) => prev.filter((t) => t.id !== todo.id));
-                            showToast({ style: Toast.Style.Success, title: "Todo marked as completed" });
-                          } else {
-                            showToast({ style: Toast.Style.Failure, title: "Failed to mark as completed" });
-                          }
-                        }}
-                        icon={Icon.Checkmark}
-                        shortcut={{ modifiers: [], key: "return" }}
-                      />
-                    )}
-                    <Action
-                      title="Move to Tomorrow"
-                      icon={Icon.Calendar}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
-                      onAction={async () => {
-                        const tomorrow = getTomorrow();
-                        const success = await updateTodo(todo.id, todo.workspace, { dueDate: tomorrow });
-                        if (success) {
-                          setTodos((prev) => prev.map((t) => (t.id === todo.id ? { ...t, dueDate: tomorrow } : t)));
-                          showToast({ style: Toast.Style.Success, title: "Moved to tomorrow" });
-                        } else {
-                          showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
-                        }
-                      }}
-                    />
-                    <Action
-                      title="Move to Next Monday"
-                      icon={Icon.Calendar}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
-                      onAction={async () => {
-                        const nextMonday = getNextMonday();
-                        const success = await updateTodo(todo.id, todo.workspace, { dueDate: nextMonday });
-                        if (success) {
-                          setTodos((prev) => prev.map((t) => (t.id === todo.id ? { ...t, dueDate: nextMonday } : t)));
-                          showToast({ style: Toast.Style.Success, title: "Moved to next Monday" });
-                        } else {
-                          showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
-                        }
-                      }}
-                    />
-                    <Action
-                      title="Next Filter"
-                      icon={Icon.ArrowDown}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "arrowDown" }}
-                      onAction={() => setFilter(getNextFilter(filter))}
-                    />
-                    <Action
-                      title="Previous Filter"
-                      icon={Icon.ArrowUp}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "arrowUp" }}
-                      onAction={() => setFilter(getPrevFilter(filter))}
-                    />
-                    <Action.Push
-                      title="Edit Todo"
-                      icon={Icon.Pencil}
-                      target={
-                        <EditTodoForm
-                          todo={todo}
-                          onEdit={async (updates) => {
-                            // Check if workspace changed
-                            const newWorkspace = updates.workspace;
-                            const workspaceChanged = newWorkspace && newWorkspace !== todo.workspace;
-
-                            if (workspaceChanged && newWorkspace) {
-                              // Create todo in new workspace
-                              const createResult = await createTodo(newWorkspace, {
-                                title: updates.title ?? todo.title,
-                                description: updates.description ?? todo.description,
-                                dueDate: updates.dueDate ?? todo.dueDate,
-                                priority: updates.priority ?? todo.priority,
-                                notes: updates.notes ?? todo.notes,
-                              });
-
-                              if (createResult.success) {
-                                // Delete from old workspace
-                                const deleteSuccess = await deleteTodo(todo.id, todo.workspace);
-                                if (deleteSuccess) {
-                                  // Update local state: remove old, add new
-                                  setTodos((prev) => [
-                                    ...prev.filter((t) => t.id !== todo.id),
-                                    {
-                                      ...todo,
-                                      ...updates,
-                                      id: createResult.pageId,
-                                      url: createResult.url,
-                                      workspace: newWorkspace,
-                                    },
-                                  ]);
-                                  showToast({ style: Toast.Style.Success, title: "Todo moved to new workspace" });
-                                } else {
-                                  showToast({
-                                    style: Toast.Style.Failure,
-                                    title: "Failed to delete from old workspace",
-                                  });
-                                }
-                              } else {
-                                showToast({ style: Toast.Style.Failure, title: "Failed to create in new workspace" });
-                              }
-                            } else {
-                              // Normal update in same workspace
-                              const success = await updateTodo(todo.id, todo.workspace, updates);
-                              if (success) {
-                                setTodos((prev) => prev.map((t) => (t.id === todo.id ? { ...t, ...updates } : t)));
-                                showToast({ style: Toast.Style.Success, title: "Todo updated" });
-                              } else {
-                                showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
-                              }
-                            }
-                          }}
-                        />
-                      }
-                      shortcut={{ modifiers: ["cmd"], key: "e" }}
-                    />
-                    <Action.CopyToClipboard
-                      content={todo.title}
-                      title="Copy Title"
-                      shortcut={{ modifiers: ["cmd"], key: "." }}
-                    />
-                    <Action
-                      title="Delete Todo"
-                      icon={Icon.Trash}
-                      style={Action.Style.Destructive}
-                      onAction={async () => {
-                        const success = await deleteTodo(todo.id, todo.workspace);
-                        if (success) {
-                          setTodos((prev) => prev.filter((t) => t.id !== todo.id));
-                          showToast({ style: Toast.Style.Success, title: "Todo deleted" });
-                        } else {
-                          showToast({ style: Toast.Style.Failure, title: "Failed to delete todo" });
-                        }
-                      }}
-                      shortcut={{ modifiers: ["ctrl"], key: "x" }}
-                    />
-                  </ActionPanel>
-                }
+                todo={todo}
+                filter={filter}
+                onFilterChange={setFilter}
+                onUpdate={(updated) => setTodos((prev) => prev.map((t) => (t.id === todo.id ? updated : t)))}
+                onDelete={(id) => setTodos((prev) => prev.filter((t) => t.id !== id))}
               />
             ))}
           </List.Section>

--- a/src/components/TodoFilterDropdown.tsx
+++ b/src/components/TodoFilterDropdown.tsx
@@ -1,0 +1,23 @@
+import { Icon, List } from "@raycast/api";
+import { capitalizeFirstLetter } from "../utils";
+import { TodoFilter } from "../types";
+
+export function TodoFilterDropdown({
+  filter,
+  onFilterChange,
+}: {
+  filter: TodoFilter;
+  onFilterChange: (value: TodoFilter) => void;
+}) {
+  return (
+    <List.Dropdown tooltip="Filter Todos" value={filter} onChange={(value) => onFilterChange(value as TodoFilter)}>
+      <List.Dropdown.Item title={capitalizeFirstLetter(TodoFilter.ALL)} value={TodoFilter.ALL} />
+      <List.Dropdown.Item
+        title={capitalizeFirstLetter(TodoFilter.PERSONAL)}
+        value={TodoFilter.PERSONAL}
+        icon={Icon.Person}
+      />
+      <List.Dropdown.Item title={capitalizeFirstLetter(TodoFilter.WORK)} value={TodoFilter.WORK} icon={Icon.Building} />
+    </List.Dropdown>
+  );
+}

--- a/src/components/TodoListItem.tsx
+++ b/src/components/TodoListItem.tsx
@@ -1,0 +1,199 @@
+import { Action, ActionPanel, Color, Icon, List, showToast, Toast } from "@raycast/api";
+import {
+  capitalizeFirstLetter,
+  formatVisualDate,
+  getPriorityColor,
+  getWorkspaceColor,
+  getWorkspaceIcon,
+  isOverdue,
+  getTomorrow,
+  getNextMonday,
+} from "../utils";
+import { Todo, Workspaces } from "../types";
+import { markTodoCompleted, updateTodo, deleteTodo, createTodo } from "../notion";
+import { EditTodoForm } from "./EditTodoForm";
+import { getNextFilter, getPrevFilter } from "../hooks/useTodos";
+import type { TodoFilter } from "../types";
+
+export function TodoListItem({
+  todo,
+  onUpdate,
+  onDelete,
+  filter,
+  onFilterChange,
+}: {
+  todo: Todo;
+  onUpdate: (updated: Todo) => void;
+  onDelete: (id: string) => void;
+  filter: TodoFilter;
+  onFilterChange: (f: TodoFilter) => void;
+}) {
+  return (
+    <List.Item
+      key={todo.id}
+      title={todo.title}
+      subtitle={todo.notes}
+      icon={todo.done ? { source: Icon.CheckCircle, tintColor: Color.Green } : Icon.Circle}
+      accessories={[
+        ...[
+          {
+            icon: { source: getWorkspaceIcon(todo.workspace), tintColor: getWorkspaceColor(todo.workspace) },
+            tooltip:
+              todo.workspace === Workspaces.PERSONAL
+                ? capitalizeFirstLetter(Workspaces.PERSONAL)
+                : capitalizeFirstLetter(Workspaces.WORK),
+          },
+          ...(todo.priority
+            ? [
+                {
+                  tag: { value: todo.priority, color: getPriorityColor(todo.priority) },
+                },
+              ]
+            : []),
+          ...(todo.dueDate
+            ? [
+                {
+                  text: isOverdue(todo.dueDate)
+                    ? `🔴 ${formatVisualDate(new Date(todo.dueDate))}`
+                    : formatVisualDate(new Date(todo.dueDate)),
+                  icon: Icon.Calendar,
+                  tooltip: new Date(todo.dueDate).toLocaleDateString(),
+                },
+              ]
+            : []),
+        ],
+      ]}
+      actions={
+        <ActionPanel>
+          {!todo.done && (
+            <Action
+              title="Mark as Completed"
+              onAction={async () => {
+                const success = await markTodoCompleted(todo.id, todo.workspace);
+                if (success) {
+                  onDelete(todo.id);
+                  showToast({ style: Toast.Style.Success, title: "Todo marked as completed" });
+                } else {
+                  showToast({ style: Toast.Style.Failure, title: "Failed to mark as completed" });
+                }
+              }}
+              icon={Icon.Checkmark}
+              shortcut={{ modifiers: [], key: "return" }}
+            />
+          )}
+          <Action
+            title="Move to Tomorrow"
+            icon={Icon.Calendar}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "t" }}
+            onAction={async () => {
+              const tomorrow = getTomorrow();
+              const success = await updateTodo(todo.id, todo.workspace, { dueDate: tomorrow });
+              if (success) {
+                onUpdate({ ...todo, dueDate: tomorrow });
+                showToast({ style: Toast.Style.Success, title: "Moved to tomorrow" });
+              } else {
+                showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
+              }
+            }}
+          />
+          <Action
+            title="Move to Next Monday"
+            icon={Icon.Calendar}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "m" }}
+            onAction={async () => {
+              const nextMonday = getNextMonday();
+              const success = await updateTodo(todo.id, todo.workspace, { dueDate: nextMonday });
+              if (success) {
+                onUpdate({ ...todo, dueDate: nextMonday });
+                showToast({ style: Toast.Style.Success, title: "Moved to next Monday" });
+              } else {
+                showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
+              }
+            }}
+          />
+          <Action
+            title="Next Filter"
+            icon={Icon.ArrowDown}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "arrowDown" }}
+            onAction={() => onFilterChange(getNextFilter(filter))}
+          />
+          <Action
+            title="Previous Filter"
+            icon={Icon.ArrowUp}
+            shortcut={{ modifiers: ["cmd", "shift"], key: "arrowUp" }}
+            onAction={() => onFilterChange(getPrevFilter(filter))}
+          />
+          <Action.Push
+            title="Edit Todo"
+            icon={Icon.Pencil}
+            target={
+              <EditTodoForm
+                todo={todo}
+                onEdit={async (updates) => {
+                  const newWorkspace = updates.workspace;
+                  const workspaceChanged = newWorkspace && newWorkspace !== todo.workspace;
+
+                  if (workspaceChanged && newWorkspace) {
+                    const createResult = await createTodo(newWorkspace, {
+                      title: updates.title ?? todo.title,
+                      description: updates.description ?? todo.description,
+                      dueDate: updates.dueDate ?? todo.dueDate,
+                      priority: updates.priority ?? todo.priority,
+                      notes: updates.notes ?? todo.notes,
+                    });
+
+                    if (createResult.success) {
+                      const deleteSuccess = await deleteTodo(todo.id, todo.workspace);
+                      if (deleteSuccess) {
+                        onUpdate({
+                          ...todo,
+                          ...updates,
+                          id: createResult.pageId,
+                          url: createResult.url,
+                          workspace: newWorkspace,
+                        });
+                        showToast({ style: Toast.Style.Success, title: "Todo moved to new workspace" });
+                      } else {
+                        showToast({
+                          style: Toast.Style.Failure,
+                          title: "Failed to delete from old workspace",
+                        });
+                      }
+                    } else {
+                      showToast({ style: Toast.Style.Failure, title: "Failed to create in new workspace" });
+                    }
+                  } else {
+                    const success = await updateTodo(todo.id, todo.workspace, updates);
+                    if (success) {
+                      onUpdate({ ...todo, ...updates });
+                      showToast({ style: Toast.Style.Success, title: "Todo updated" });
+                    } else {
+                      showToast({ style: Toast.Style.Failure, title: "Failed to update todo" });
+                    }
+                  }
+                }}
+              />
+            }
+            shortcut={{ modifiers: ["cmd"], key: "e" }}
+          />
+          <Action.CopyToClipboard content={todo.title} title="Copy Title" shortcut={{ modifiers: ["cmd"], key: "." }} />
+          <Action
+            title="Delete Todo"
+            icon={Icon.Trash}
+            style={Action.Style.Destructive}
+            onAction={async () => {
+              const success = await deleteTodo(todo.id, todo.workspace);
+              if (success) {
+                onDelete(todo.id);
+                showToast({ style: Toast.Style.Success, title: "Todo deleted" });
+              } else {
+                showToast({ style: Toast.Style.Failure, title: "Failed to delete todo" });
+              }
+            }}
+            shortcut={{ modifiers: ["ctrl"], key: "x" }}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { fetchTodosFromWorkspace } from "../notion";
+import { Todo, TodoDateGroup, TodoFilter, Workspaces } from "../types";
+
+function getDateCategory(dateStr?: string): TodoDateGroup {
+  if (!dateStr) return TodoDateGroup.NO_DATE;
+  const today = new Date();
+  const date = new Date(dateStr);
+  today.setHours(0, 0, 0, 0);
+  date.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays < 0) return TodoDateGroup.PAST;
+  if (diffDays === 0) return TodoDateGroup.TODAY;
+  if (diffDays === 1) return TodoDateGroup.TOMORROW;
+  if (diffDays > 1 && diffDays <= 7) return TodoDateGroup.NEXT_WEEK;
+  if (diffDays > 7) return TodoDateGroup.LATER;
+  return TodoDateGroup.NO_DATE;
+}
+
+function groupByDate(todos: Todo[]): Record<TodoDateGroup, Todo[]> {
+  const grouped: Record<TodoDateGroup, Todo[]> = {
+    [TodoDateGroup.PAST]: [],
+    [TodoDateGroup.TODAY]: [],
+    [TodoDateGroup.TOMORROW]: [],
+    [TodoDateGroup.NEXT_WEEK]: [],
+    [TodoDateGroup.LATER]: [],
+    [TodoDateGroup.NO_DATE]: [],
+  };
+  todos.forEach((todo) => {
+    const cat = getDateCategory(todo.dueDate);
+    grouped[cat].push(todo);
+  });
+  return grouped;
+}
+
+const FILTERS: TodoFilter[] = [TodoFilter.ALL, TodoFilter.PERSONAL, TodoFilter.WORK];
+
+export function getNextFilter(current: TodoFilter): TodoFilter {
+  const idx = FILTERS.indexOf(current);
+  return FILTERS[(idx + 1) % FILTERS.length];
+}
+
+export function getPrevFilter(current: TodoFilter): TodoFilter {
+  const idx = FILTERS.indexOf(current);
+  return FILTERS[(idx - 1 + FILTERS.length) % FILTERS.length];
+}
+
+export function filterTodos(todos: Todo[], filter: TodoFilter): Todo[] {
+  return todos
+    .filter((todo) => {
+      if (filter === TodoFilter.PERSONAL) return todo.workspace === Workspaces.PERSONAL && !todo.done;
+      if (filter === TodoFilter.WORK) return todo.workspace === Workspaces.WORK && !todo.done;
+      return !todo.done;
+    })
+    .sort((a, b) => {
+      if (!a.dueDate) return 1;
+      if (!b.dueDate) return -1;
+      return a.dueDate.localeCompare(b.dueDate);
+    });
+}
+
+export function useTodos() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<TodoFilter>(TodoFilter.ALL);
+
+  useEffect(() => {
+    async function loadTodos() {
+      setLoading(true);
+      const [personalTodos, workTodos] = await Promise.all([
+        fetchTodosFromWorkspace(Workspaces.PERSONAL),
+        fetchTodosFromWorkspace(Workspaces.WORK),
+      ]);
+      setTodos([...personalTodos, ...workTodos]);
+      setLoading(false);
+    }
+    loadTodos();
+  }, []);
+
+  const filteredTodos = filterTodos(todos, filter);
+  const grouped = groupByDate(filteredTodos);
+
+  return { todos, setTodos, loading, filter, setFilter, grouped };
+}


### PR DESCRIPTION
## Description

Refactor the 284-line `GetTodos` component to improve maintainability and testability:

- **Extract `useTodos` hook** (`src/hooks/useTodos.ts`): data fetching, filtering, sorting, and date-grouping logic
- **Extract `TodoListItem`** (`src/components/TodoListItem.tsx`): the `<List.Item>` block with all 7 action handlers
- **Extract `TodoFilterDropdown`** (`src/components/TodoFilterDropdown.tsx`): the workspace filter dropdown
- **Simplify `GetTodos.tsx`**: reduced from 326 to ~40 lines, now just orchestrates sub-components

```
GetTodos.tsx (326 lines) → GetTodos.tsx (~40 lines) + useTodos.ts + TodoListItem.tsx + TodoFilterDropdown.tsx
```

Closes #9

## Testing

- [x] Lints pass
- [x] Tests pass
- [x] Type check passes