### PR TITLE
[pipelines] Enable branch protection on main branch

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security
+
+## Branch Protection
+
+The `main` branch is protected with the following rules:
+
+- **Required pull request reviews**: At least 1 approval before merging
+- **Dismiss stale reviews**: Reviews are dismissed when new commits are pushed
+- **Required status checks**: `lint`, `typecheck`, and `build` must pass
+- **Strict status checks**: Branches must be up-to-date with `main`
+- **Enforce for admins**: Yes
+- **Direct pushes**: Blocked
+
+All changes must go through a pull request.


### PR DESCRIPTION
## Description

Enable branch protection on the `main` branch via GitHub API with the following rules:

- **Required pull request reviews**: At least 1 approval before merging
- **Dismiss stale reviews**: When new commits are pushed
- **Required status checks**: `lint`, `typecheck`, `build` must pass (strict mode)
- **Enforce for admins**: Yes
- **Direct pushes**: Blocked
- **Force pushes**: Blocked

A `SECURITY.md` file documents these rules in the repository.

Closes #4

## Verification

- [x] Branch protection applied via API
- [x] Verified with `gh api` GET request