### PR TITLE
[refactor] Code quality: remove unused exports/deps, memoize, improve error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@notionhq/client": "^5.4.0",
         "@raycast/api": "^1.103.9",
-        "@raycast/utils": "^2.2.6",
         "react": "^19.2.0"
       },
       "devDependencies": {
@@ -1607,24 +1606,6 @@
         "eslint": ">=8.23.0"
       }
     },
-    "node_modules/@raycast/utils": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.6.tgz",
-      "integrity": "sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@raycast/api": ">=1.99.4",
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -2835,15 +2816,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "dependencies": {
     "@notionhq/client": "^5.4.0",
     "@raycast/api": "^1.103.9",
-    "@raycast/utils": "^2.2.6",
     "react": "^19.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@raycast/api':
         specifier: ^1.103.9
         version: 1.103.9(@types/node@22.13.10)(@types/react@19.2.7)
-      '@raycast/utils':
-        specifier: ^2.2.6
-        version: 2.2.6(@raycast/api@1.103.9(@types/node@22.13.10)(@types/react@19.2.7))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -556,15 +553,6 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
-  '@raycast/utils@2.2.6':
-    resolution: {integrity: sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==}
-    peerDependencies:
-      '@raycast/api': '>=1.99.4'
-      react: '>=19.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -934,10 +922,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2178,13 +2162,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@raycast/utils@2.2.6(@raycast/api@1.103.9(@types/node@22.13.10)(@types/react@19.2.7))(react@19.2.0)':
-    dependencies:
-      '@raycast/api': 1.103.9(@types/node@22.13.10)(@types/react@19.2.7)
-      dequal: 2.0.3
-    optionalDependencies:
-      react: 19.2.0
-
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -2540,8 +2517,6 @@ snapshots:
       supports-color: 8.1.1
 
   deep-is@0.1.4: {}
-
-  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 

--- a/src/components/QuickAddTodo.tsx
+++ b/src/components/QuickAddTodo.tsx
@@ -115,7 +115,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
   }
 
   if (loading) {
-    return <Detail isLoading={true} markdown="🤖 Understanding your todo with AI..." />;
+    return <Detail isLoading={true} markdown="Understanding your todo with AI..." />;
   }
 
   if (parseError || !parsedTodo) {
@@ -177,7 +177,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
         </ActionPanel>
       }
     >
-      <Form.Description title="🤖 AI Parsed" text={`From: "${userInput}"`} />
+      <Form.Description title="AI Parsed" text={`From: "${userInput}"`} />
       <Form.Separator />
       <Form.Dropdown id="workspace" title="Target Workspace" defaultValue={parsedTodo.workspace}>
         <Form.Dropdown.Item value="personal" title="Personal" />

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchTodosFromWorkspace } from "../notion";
 import { Todo, TodoDateGroup, TodoFilter, Workspaces } from "../types";
 
@@ -77,8 +77,8 @@ export function useTodos() {
     loadTodos();
   }, []);
 
-  const filteredTodos = filterTodos(todos, filter);
-  const grouped = groupByDate(filteredTodos);
+  const filteredTodos = useMemo(() => filterTodos(todos, filter), [todos, filter]);
+  const grouped = useMemo(() => groupByDate(filteredTodos), [filteredTodos]);
 
   return { todos, setTodos, loading, filter, setFilter, grouped };
 }

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -12,13 +12,13 @@ import {
 } from "../types";
 import { mapNotionPageToTodo } from "../utils";
 
-export function getNotionClient(workspace: Workspaces): Client {
+function getNotionClient(workspace: Workspaces): Client {
   const prefs = getPreferenceValues<Preferences>();
   const token = workspace === Workspaces.PERSONAL ? prefs.personal_notion_token : prefs.work_notion_token;
   return new Client({ auth: token });
 }
 
-export function getDatabaseId(workspace: Workspaces): string {
+function getDatabaseId(workspace: Workspaces): string {
   const prefs = getPreferenceValues<Preferences>();
   return workspace === Workspaces.PERSONAL ? prefs.personal_db_id : prefs.work_db_id;
 }
@@ -32,7 +32,7 @@ export async function deleteTodo(pageId: string, workspace: Workspaces): Promise
     });
     return true;
   } catch (error) {
-    console.error("Failed to delete todo:", error);
+    console.debug("Failed to delete todo:", error);
     return false;
   }
 }
@@ -119,7 +119,7 @@ export async function markTodoCompleted(pageId: string, workspace: Workspaces): 
     });
     return true;
   } catch (error) {
-    console.error("Failed to mark todo completed:", error);
+    console.debug("Failed to mark todo completed:", error);
     return false;
   }
 }
@@ -140,15 +140,12 @@ export async function updateTodo(pageId: string, workspace: Workspaces, updates:
     });
     return true;
   } catch (error) {
-    console.error("Failed to update todo:", error);
+    console.debug("Failed to update todo:", error);
     return false;
   }
 }
 
-export function getNotionToken(workspace: Workspaces): string {
-  const prefs = getPreferenceValues<Preferences>();
-  return workspace === Workspaces.PERSONAL ? prefs.personal_notion_token : prefs.work_notion_token;
-}
+const NOTION_VERSION = "2022-06-28";
 
 export async function fetchTodosFromWorkspace(workspace: Workspaces): Promise<Todo[]> {
   const token = getNotionToken(workspace);
@@ -161,7 +158,7 @@ export async function fetchTodosFromWorkspace(workspace: Workspaces): Promise<To
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
-        "Notion-Version": "2022-06-28",
+        "Notion-Version": NOTION_VERSION,
       },
       body: JSON.stringify({
         sorts: [{ timestamp: "created_time", direction: "descending" }],
@@ -174,7 +171,12 @@ export async function fetchTodosFromWorkspace(workspace: Workspaces): Promise<To
     const data = (await response.json()) as { results: NotionPage[] };
     return data.results.map((page) => mapNotionPageToTodo(page, fields, workspace));
   } catch (error: unknown) {
-    console.error(`Error fetching ${workspace} todos:`, error);
+    console.debug(`Error fetching ${workspace} todos:`, error);
     return [];
   }
+}
+
+function getNotionToken(workspace: Workspaces): string {
+  const prefs = getPreferenceValues<Preferences>();
+  return workspace === Workspaces.PERSONAL ? prefs.personal_notion_token : prefs.work_notion_token;
 }

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -33,7 +33,7 @@ export function mapNotionPageToTodo(
   };
 }
 
-export function extractTitle(titleProperty: NotionPageTitle): string {
+function extractTitle(titleProperty: NotionPageTitle): string {
   const titleArr = titleProperty?.title ?? [];
   if (Array.isArray(titleArr)) {
     return titleArr.map((t) => String(t.plain_text ?? "")).join("") || "Untitled";
@@ -41,7 +41,7 @@ export function extractTitle(titleProperty: NotionPageTitle): string {
   return "Untitled";
 }
 
-export function extractRichText(richTextProperty: NotionRichText): string | undefined {
+function extractRichText(richTextProperty: NotionRichText): string | undefined {
   const richArr = richTextProperty?.rich_text ?? [];
   if (Array.isArray(richArr)) {
     return richArr.map((t) => String(t.plain_text ?? "")).join("");
@@ -49,11 +49,11 @@ export function extractRichText(richTextProperty: NotionRichText): string | unde
   return undefined;
 }
 
-export function extractCheckbox(checkboxProperty: NotionCheckbox): boolean {
+function extractCheckbox(checkboxProperty: NotionCheckbox): boolean {
   return checkboxProperty?.checkbox === true;
 }
 
-export function extractDate(dateProperty: NotionDate): string | undefined {
+function extractDate(dateProperty: NotionDate): string | undefined {
   const dateObj = dateProperty?.date;
   if (dateObj?.start && typeof dateObj.start === "string") {
     return dateObj.start;
@@ -61,7 +61,7 @@ export function extractDate(dateProperty: NotionDate): string | undefined {
   return undefined;
 }
 
-export function extractSelect(selectProperty: NotionSelect): import("../types").Priority | undefined {
+function extractSelect(selectProperty: NotionSelect): import("../types").Priority | undefined {
   const selectObj = selectProperty?.select;
   const value = selectObj?.name;
   if (typeof value === "string" && Object.values(Priority).includes(value as Priority)) {

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -1,11 +1,17 @@
 // Preferences helpers
 import { Preferences } from "../types";
 
-export function missingPreferences(prefs: Preferences): string[] {
+export type MissingPreferenceKey =
+  | "Personal Notion Token"
+  | "Personal Database ID"
+  | "Work Notion Token"
+  | "Work Database ID";
+
+export function missingPreferences(prefs: Preferences): MissingPreferenceKey[] {
   return [
     !prefs.personal_notion_token && "Personal Notion Token",
     !prefs.personal_db_id && "Personal Database ID",
     !prefs.work_notion_token && "Work Notion Token",
     !prefs.work_db_id && "Work Database ID",
-  ].filter(Boolean) as string[];
+  ].filter(Boolean) as MissingPreferenceKey[];
 }


### PR DESCRIPTION
## Description

Code quality improvements found in the codebase scan.

### Changes
- Remove unused @raycast/utils dependency (#30)
- Make internal extractor functions module-private (#31)
- Replace console.error with console.debug (#34)
- Replace hardcoded emojis with text (#36)
- Make internal helper functions module-private (#41)
- Memoize filteredTodos and grouped in useTodos (#43)
- Extract NOTION_VERSION constant (#46)
- Add MissingPreferenceKey type (#49)

### Testing
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes

Closes #30, Closes #31, Closes #34, Closes #36, Closes #41, Closes #43, Closes #46, Closes #49