### PR TITLE
[refactor] Remove description/notes duplication, fix stale closure, remove unused export

### DIFF
--- a/src/components/AddTodo.tsx
+++ b/src/components/AddTodo.tsx
@@ -34,7 +34,7 @@ export default function AddNotionTodoCommand() {
   async function handleSubmit(values: {
     workspace: Workspaces;
     title: string;
-    description?: string;
+    notes?: string;
     dueDate?: Date;
     priority?: Priority;
   }) {
@@ -43,7 +43,7 @@ export default function AddNotionTodoCommand() {
     try {
       const result = await createTodo(values.workspace, {
         title: values.title,
-        description: values.description,
+        notes: values.notes,
         dueDate: values.dueDate ? formatLocalDate(values.dueDate) : undefined,
         priority: values.priority,
       });
@@ -78,7 +78,7 @@ export default function AddNotionTodoCommand() {
         <Form.Dropdown.Item value="work" title="Work" />
       </Form.Dropdown>
       <Form.TextField id="title" title="Title" placeholder="Todo title" autoFocus />
-      <Form.TextArea id="description" title="Description / Notes" placeholder="Optional notes" />
+      <Form.TextArea id="notes" title="Notes" placeholder="Optional notes" />
       <Form.DatePicker id="dueDate" title="Due Date" />
       <Form.Dropdown id="priority" title="Priority">
         {Object.values(Priority).map((priority) => (

--- a/src/components/EditTodoForm.tsx
+++ b/src/components/EditTodoForm.tsx
@@ -7,7 +7,7 @@ export function EditTodoForm({ todo, onEdit }: { todo: Todo; onEdit: (updated: P
   const [loading, setLoading] = useState(false);
   const [workspace, setWorkspace] = useState<Workspaces>(todo.workspace);
   const [title, setTitle] = useState(todo.title);
-  const [description, setDescription] = useState(todo.description ?? "");
+  const [notes, setNotes] = useState(todo.notes ?? "");
   const [dueDate, setDueDate] = useState<Date | undefined>(todo.dueDate ? new Date(todo.dueDate) : undefined);
   const [priority, setPriority] = useState<Priority | undefined>(todo.priority);
 
@@ -15,10 +15,9 @@ export function EditTodoForm({ todo, onEdit }: { todo: Todo; onEdit: (updated: P
     setLoading(true);
     await onEdit({
       title,
-      description,
+      notes,
       dueDate: dueDate ? formatLocalDate(dueDate) : undefined,
       priority,
-      notes: todo.notes,
       workspace,
     });
     setLoading(false);
@@ -43,7 +42,7 @@ export function EditTodoForm({ todo, onEdit }: { todo: Todo; onEdit: (updated: P
         <Form.Dropdown.Item value={Workspaces.WORK} title="Work" />
       </Form.Dropdown>
       <Form.TextField id="title" title="Title" value={title} onChange={setTitle} autoFocus />
-      <Form.TextArea id="description" title="Description / Notes" value={description} onChange={setDescription} />
+      <Form.TextArea id="notes" title="Notes" value={notes} onChange={setNotes} />
       <Form.DatePicker
         id="dueDate"
         title="Due Date"

--- a/src/components/QuickAddTodo.tsx
+++ b/src/components/QuickAddTodo.tsx
@@ -99,7 +99,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
     }
 
     parseWithAI();
-  }, [userInput]);
+  }, [userInput, missing]);
 
   if (missing.length > 0) {
     return (
@@ -134,7 +134,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
   async function handleSubmit(values: {
     workspace: Workspaces;
     title: string;
-    description?: string;
+    notes?: string;
     dueDate?: Date;
     priority?: Priority;
   }) {
@@ -143,7 +143,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
     try {
       const result = await createTodo(values.workspace, {
         title: values.title,
-        description: values.description,
+        notes: values.notes,
         dueDate: values.dueDate ? values.dueDate.toISOString().split("T")[0] : undefined,
         priority: values.priority,
       });
@@ -184,7 +184,7 @@ export default function QuickAddTodoCommand(props: LaunchProps<{ arguments: Quic
         <Form.Dropdown.Item value="work" title="Work" />
       </Form.Dropdown>
       <Form.TextField id="title" title="Title" defaultValue={parsedTodo.title} />
-      <Form.TextArea id="description" title="Description / Notes" defaultValue={parsedTodo.description || ""} />
+      <Form.TextArea id="notes" title="Notes" defaultValue={parsedTodo.notes || ""} />
       <Form.DatePicker id="dueDate" title="Due Date" defaultValue={dueDateValue} />
       <Form.Dropdown id="priority" title="Priority" defaultValue={parsedTodo.priority || ""}>
         <Form.Dropdown.Item value="" title="No Priority" />

--- a/src/components/TodoListItem.tsx
+++ b/src/components/TodoListItem.tsx
@@ -136,10 +136,9 @@ export function TodoListItem({
                   if (workspaceChanged && newWorkspace) {
                     const createResult = await createTodo(newWorkspace, {
                       title: updates.title ?? todo.title,
-                      description: updates.description ?? todo.description,
+                      notes: updates.notes ?? todo.notes,
                       dueDate: updates.dueDate ?? todo.dueDate,
                       priority: updates.priority ?? todo.priority,
-                      notes: updates.notes ?? todo.notes,
                     });
 
                     if (createResult.success) {

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -45,7 +45,7 @@ export function getPrevFilter(current: TodoFilter): TodoFilter {
   return FILTERS[(idx - 1 + FILTERS.length) % FILTERS.length];
 }
 
-export function filterTodos(todos: Todo[], filter: TodoFilter): Todo[] {
+function filterTodos(todos: Todo[], filter: TodoFilter): Todo[] {
   return todos
     .filter((todo) => {
       if (filter === TodoFilter.PERSONAL) return todo.workspace === Workspaces.PERSONAL && !todo.done;

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -60,12 +60,12 @@ export async function createTodo(
     },
   };
 
-  if (input.description) {
+  if (input.notes) {
     properties[FIELDS.notes] = {
       rich_text: [
         {
           text: {
-            content: input.description,
+            content: input.notes,
           },
         },
       ],
@@ -133,7 +133,6 @@ export async function updateTodo(pageId: string, workspace: Workspaces, updates:
       properties: {
         ...(updates.title ? { [FIELDS.title]: { title: [{ text: { content: updates.title } }] } } : {}),
         ...(updates.priority ? { [FIELDS.priority]: { select: { name: updates.priority } } } : {}),
-        ...(updates.description ? { [FIELDS.notes]: { rich_text: [{ text: { content: updates.description } }] } } : {}),
         ...(updates.notes ? { [FIELDS.notes]: { rich_text: [{ text: { content: updates.notes } }] } } : {}),
         ...(updates.dueDate ? { [FIELDS.date]: { date: { start: updates.dueDate } } } : {}),
       },

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -25,7 +25,6 @@ export enum Priority {
 export interface Todo {
   id: string;
   title: string;
-  description?: string;
   done: boolean;
   dueDate?: string;
   priority?: Priority;
@@ -34,9 +33,9 @@ export interface Todo {
   url: string;
 }
 
-export type CreateTodoInput = Pick<Todo, "title" | "description" | "dueDate" | "priority" | "notes">;
+export type CreateTodoInput = Pick<Todo, "title" | "dueDate" | "priority" | "notes">;
 
-export type ParsedTodo = Pick<Todo, "title" | "workspace" | "description" | "dueDate" | "priority">;
+export type ParsedTodo = Pick<Todo, "title" | "workspace" | "dueDate" | "priority" | "notes">;
 
 export interface QuickAddArguments {
   text: string;

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -27,7 +27,6 @@ export function mapNotionPageToTodo(
     dueDate: extractDate(props[fields.date] as NotionDate) ?? undefined,
     priority: extractSelect(props[fields.priority] as NotionSelect) ?? undefined,
     notes: notes ?? undefined,
-    description: notes ?? undefined, // Explicitly set description (optional)
     workspace,
     url: page.url,
   };


### PR DESCRIPTION
## Description

Iteration 3 fixes remaining issues from the final discovery scan.

### Changes
- Remove duplicate `description` field from Todo type — both `description` and `notes` mapped to the same Notion field. Standardize on `notes` everywhere (8 files updated)
- Fix stale closure in QuickAddTodo useEffect — add `missing` to dependency array
- Remove unused `export` from `filterTodos` in useTodos (only used internally)

### Testing
- [x] `npm run lint` passes (4 no-console warnings, expected)
- [x] `npm run typecheck` passes
- [x] `npm test` passes (14 tests, 2 test files)

Closes #0 (cleanup scan findings)